### PR TITLE
Add a shell script to register with standard CLI tools

### DIFF
--- a/register-with-shell.sh
+++ b/register-with-shell.sh
@@ -37,76 +37,117 @@ MAINNET_CHAINID=1
 SIG_EXPIRY_SECONDS=300
 export ETH_RPC_URL=https://rpc.holesky.ethpandaops.io
 
-chain_id=$(cast chain-id)
-printf "Chain id: ${chain_id}\n"
+# --- Functions ---
 
-# The signature you create + send is valid for SIG_EXPIRY_SECONDS
-(( expiry_timestamp = $SIG_EXPIRY_SECONDS + $(cast block -f timestamp) ))
-
-# Determine contract addresses based on the chain ID
-if [ $chain_id -eq $HOLESKY_CHAINID ]; then
-    echo "Registering with Lagrange ZK Coprocessor on Holesky Testnet"
-    ZKMR_SERVICE_MANAGER_ADDR=0xf98D5De1014110C65c51b85Ea55f73863215CC10
-    ZKMR_STAKE_REGISTRY_ADDR=0xf724cDC7C40fd6B59590C624E8F0E5E3843b4BE4
-    EIGEN_AVS_DIRECTORY_ADDR=0x055733000064333CaDDbC92763c58BF0192fFeBf
-elif [ $chain_id -eq $MAINNET_CHAINID ]; then
-    echo "Mainnet is not live yet"
-    exit 1
-else
-    echo "Unknown chain ID: $chainId"
-    exit 1
-fi
-
-# --- Script Logic ---
 # The lagrange key should only be used for this AVS.
 # It is an ECDSA secp256k1 keypair; the same as ethereum
-LAGR_KEYPAIR=$(openssl ecparam -name secp256k1 -genkey -noout | openssl ec -text -noout)
-LAGR_KEY=0x$(echo $LAGR_KEYPAIR | grep priv -A 3 | tail -n +2 | tr -d '\n[:space:]:' | sed 's/^00//')
-LAGR_PUB_KEY=$(echo $LAGR_KEYPAIR | grep pub -A 5 | tail -n +2 | tr -d '\n[:space:]:' | sed 's/^04//')
+generate_lagrange_keypair() {
+    local keypair
+    keypair=$(openssl ecparam -name secp256k1 -genkey -noout | openssl ec -text -noout)
+    LAGR_KEY=0x$(echo $keypair | grep priv -A 3 | tail -n +2 | tr -d '\n[:space:]:' | sed 's/^00//')
 
-# 32 bytes of X coordinate of ECDSA secp256k1 public key
-pubkeyX=0x${LAGR_PUB_KEY:0:64}
-# 32 bytes of Y coordinate of ECDSA secp256k1 public key
-pubkeyY=0x${LAGR_PUB_KEY:64:64}
+    local pub_key
+    pub_key=$(echo $keypair | grep pub -A 5 | tail -n +2 | tr -d '\n[:space:]:' | sed 's/^04//')
 
-printf "Public Key: $LAGR_PUB_KEY\n"
-printf "pubkeyX: $pubkeyX\n"
-printf "pubkeyY: $pubkeyY\n"
+    # 32 bytes of X coordinate of ECDSA secp256k1 public key
+    PUBKEY_X=0x${pub_key:0:64}
+    # 32 bytes of Y coordinate of ECDSA secp256k1 public key
+    PUBKEY_Y=0x${pub_key:64:64}
+}
+
+# === MODIFY ME ! ===
+# Implement logic to store the $LAGR_KEY securely.
+store_lagrange_key() {
+    # export LAGR_KEY
+    # echo "LAGR_KEY: $LAGR_KEY"
+    echo "Implement the \`store_lagrange_key\` function before registering"
+    exit 1
+}
+
+# Determine contract addresses based on the chain ID
+set_contract_addresses() {
+    local chain_id = $(cast chain-id)
+
+    if [ -z "$chain_id" ]; then
+        echo "Error: Unable to fetch chain ID."
+        exit 1
+    fi
+    printf "Chain id: ${CHAIN_ID}\n"
+
+    if [ "$chain_id" -eq "$HOLESKY_CHAINID" ]; then
+        echo "Registering with Lagrange ZK Coprocessor on Holesky Testnet"
+        ZKMR_SERVICE_MANAGER_ADDR=0xf98D5De1014110C65c51b85Ea55f73863215CC10
+        ZKMR_STAKE_REGISTRY_ADDR=0xf724cDC7C40fd6B59590C624E8F0E5E3843b4BE4
+        EIGEN_AVS_DIRECTORY_ADDR=0x055733000064333CaDDbC92763c58BF0192fFeBf
+    elif [ "$chain_id" -eq "$MAINNET_CHAINID" ]; then
+        echo "Mainnet is not live yet"
+        exit 1
+    else
+        echo "Unknown chain ID: $chain_id"
+        exit 1
+    fi
+}
+
+# The signature you create + send is valid for SIG_EXPIRY_SECONDS
+calculate_expiry_timestamp() {
+    (( EXPIRY_TIMESTAMP = $SIG_EXPIRY_SECONDS + $(cast block -f timestamp) ))
+}
 
 # A salt for your signature
-salt=0x$(openssl rand -hex 32)
+generate_salt() {
+    SALT=0x$(openssl rand -hex 32)
+}
 
+# Call read-only method on eigenlayer contract to get hash to sign for registration tx
+calculate_registration_hash() {
+    HASH=$(cast call $EIGEN_AVS_DIRECTORY_ADDR \
+        "calculateOperatorAVSRegistrationDigestHash(address,address,bytes32,uint256)" \
+        "$OPERATOR_ADDR" \
+        "$ZKMR_SERVICE_MANAGER_ADDR" \
+        "${SALT}" \
+        "${EXPIRY_TIMESTAMP}")
+    if [ -z "$HASH" ]; then
+        echo "Error: Unable to calculate registration hash."
+        exit 1
+    fi
+    printf "\nRegistration hash:\n${HASH}\n"
+}
+
+# Sign the registration hash with your ETH_KEY
+sign_registration_hash() {
+    SIGNATURE=$(cast wallet sign --private-key $ETH_KEY $hash)
+    printf "\nRegistration signature:\n${SIGNATURE}"
+}
+
+# === MODIFY ME ! ===
+# Register with ZKMR contract using your signature and public key component of your new $LAGR_KEY
+register_operator() {
+    cast send $ZKMR_STAKE_REGISTRY_ADDR \
+        "registerOperator((uint256,uint256),(bytes,bytes32,uint256))" \
+        "(${PUBKEY_X},${PUBKEY_Y})" \
+        "(${SIGNATURE},${SALT},${EXPIRY_TIMESTAMP})" \
+        # === MODIFY ME ! ===
+        --private-key $ETH_KEY # This line can be adjusted for other signers
+        # --aws, --ledger, --trezor, etc.
+
+    printf "\nSuccessfully Registered!\n"
+}
+
+## --- Main Script ---
+generate_lagrange_keypair
+set_contract_addresses
+calculate_expiry_timestamp
+generate_salt
+
+printf "PUBKEY_X: $PUBKEY_X\n"
+printf "PUBKEY_Y: $PUBKEY_Y\n"
 printf "\nOperator Address: $OPERATOR_ADDR\n"
 printf "ZKMRServiceManager contract: $ZKMR_SERVICE_MANAGER_ADDR\n"
 printf "ZKMRStakeRegistry contract: $ZKMR_STAKE_REGISTRY_ADDR\n"
-printf "Salt for signature: $salt\n"
-printf "Signature expires at: $expiry_timestamp"
+printf "Salt for signature: $SALT\n"
+printf "Signature expires at: $EXPIRY_TIMESTAMP\n"
 
-# Call read-only method on eigenlayer contract to get hash to sign for registration tx
-hash=$(cast call $EIGEN_AVS_DIRECTORY_ADDR \
-    "calculateOperatorAVSRegistrationDigestHash(address,address,bytes32,uint256)" \
-    "$OPERATOR_ADDR" \
-    "$ZKMR_SERVICE_MANAGER_ADDR" \
-    "${salt}" \
-    "${expiry_timestamp}")
-
-printf "\nRegistration hash:\n${hash}"
-
-# Sign the output
-signature=$(cast wallet sign --private-key $ETH_KEY $hash)
-printf "\nRegistration signature:\n${signature}"
-
-# Register with ZKMR contract using your signature and public key component of your new $LAGR_KEY
-cast send $ZKMR_STAKE_REGISTRY_ADDR \
-    "registerOperator((uint256,uint256),(bytes,bytes32,uint256))" \
-    "(${pubkeyX},${pubkeyY})" \
-    "(${signature},${salt},${expiry_timestamp})" \
-    # === MODIFY ME ! ===
-    --private-key $ETH_KEY # Specify a signer here as you see fit
-    # --aws, --ledger, --trezor, etc.
-
-printf "\nSuccessfully Registered!"
-
-# === MODIFY ME ! ===
-# Modify the script to store the $LAGR_KEY somewhere safe
-# export LAGR_KEY
+calculate_registration_hash
+sign_registration_hash
+register_operator
+store_lagrange_key

--- a/register-with-shell.sh
+++ b/register-with-shell.sh
@@ -60,8 +60,9 @@ fi
 # --- Script Logic ---
 # The lagrange key should only be used for this AVS.
 # It is an ECDSA secp256k1 keypair; the same as ethereum
-LAGR_KEY=$(openssl ecparam -name secp256k1 -genkey -noout | openssl ec -text -noout)
-LAGR_PUB_KEY=$(echo $LAGR_KEY | grep pub -A 5 | tail -n +2 | tr -d '\n[:space:]:' | sed 's/^04//')
+LAGR_KEYPAIR=$(openssl ecparam -name secp256k1 -genkey -noout | openssl ec -text -noout)
+LAGR_KEY=0x$(echo $LAGR_KEYPAIR | grep priv -A 3 | tail -n +2 | tr -d '\n[:space:]:' | sed 's/^00//')
+LAGR_PUB_KEY=$(echo $LAGR_KEYPAIR | grep pub -A 5 | tail -n +2 | tr -d '\n[:space:]:' | sed 's/^04//')
 
 # 32 bytes of X coordinate of ECDSA secp256k1 public key
 pubkeyX=0x${LAGR_PUB_KEY:0:64}
@@ -102,6 +103,7 @@ cast send $ZKMR_STAKE_REGISTRY_ADDR \
     "(${signature},${salt},${expiry_timestamp})" \
     # === MODIFY ME ! ===
     --private-key $ETH_KEY # Specify a signer here as you see fit
+    # --aws, --ledger, --trezor, etc.
 
 printf "\nSuccessfully Registered!"
 

--- a/register-with-shell.sh
+++ b/register-with-shell.sh
@@ -113,10 +113,11 @@ calculate_registration_hash() {
     printf "\nRegistration hash:\n${HASH}\n"
 }
 
+# === MODIFY ME ! ===
 # Sign the registration hash with your ETH_KEY
 sign_registration_hash() {
-    SIGNATURE=$(cast wallet sign --private-key $ETH_KEY $hash)
-    printf "\nRegistration signature:\n${SIGNATURE}"
+    SIGNATURE=$(cast wallet sign --private-key $ETH_KEY $HASH)
+    printf "\nRegistration signature:\n${SIGNATURE}\n"
 }
 
 # === MODIFY ME ! ===

--- a/register-with-shell.sh
+++ b/register-with-shell.sh
@@ -1,0 +1,110 @@
+#!/bin/zsh
+# --- Description ---
+# An example script using `cast` to register for the Lagrange ZK Coprocessor AVS
+# This is an alternative to our Rust CLI. You can modify it to suit your operational setup.
+# This script does 3 things:
+#   1. Generate a new LAGR_KEY to be used to authenticate with the Gateway + sign the proofs you generate. It is needed at runtime while running the worker
+#   2. Sign a message with your Eigenlayer ETH_KEY. This is your very sensitive `withdrawal key` https://docs.eigenlayer.xyz/eigenlayer/operator-guides/key-management/intro#withdrawal-keys
+#   3. Send a transaction to the ZKMRStakeRegistry to register for the ZK Coprocessor AVS
+# The transaction requires as input:
+#   1. The public key component of your new LAGR_KEY
+#   2. A signed message from your ETH_KEY
+#   3. It must be signed with your ETH_KEY i.e. `cast send --private-key $ETH_KEY`
+#
+# You need to change the "MODIFY ME!" section to load your ETH_KEY safely.
+# You don't need to load the ETH_KEY into the environment at all if you use a remote signer.
+# You should just modify the `cast send` command at the end of the script to sign the tx in a way that meets your security needs.
+# You also need to update the OPERATOR_ADDR variable to match your address.
+
+# --- Dependencies ---
+# 1. zsh
+# 2. `cast` - a binary from the foundry toolkit https://github.com/foundry-rs/foundry?tab=readme-ov-file
+# 3. `openssl` - to generate your new ECDSA secp256k1 LAGR_KEY to be used only for the ZK Coprocessor AVS
+# 4. `jq` - only needed for the demo; see === MODIFY ME! === section below
+
+# ==== MODIFY ME! ====
+# --- Secrets ---
+# This is just an example. You can generate/acquire/inject your operator key however you'd like
+OPERATOR_KEY_ADDR_TUPLE=$(cast wallet new --json)
+ETH_KEY=$(echo $OPERATOR_KEY_ADDR_TUPLE | jq -r ".[0].private_key")
+OPERATOR_ADDR=$(echo $OPERATOR_KEY_ADDR_TUPLE | jq -r ".[0].address")
+
+# --- Constants ---
+HOLESKY_CHAINID=17000
+MAINNET_CHAINID=1
+
+# --- Configuration ---
+SIG_EXPIRY_SECONDS=300
+export ETH_RPC_URL=https://rpc.holesky.ethpandaops.io
+
+chain_id=$(cast chain-id)
+printf "Chain id: ${chain_id}\n"
+
+# The signature you create + send is valid for SIG_EXPIRY_SECONDS
+(( expiry_timestamp = $SIG_EXPIRY_SECONDS + $(cast block -f timestamp) ))
+
+# Determine contract addresses based on the chain ID
+if [ $chain_id -eq $HOLESKY_CHAINID ]; then
+    echo "Registering with Lagrange ZK Coprocessor on Holesky Testnet"
+    ZKMR_SERVICE_MANAGER_ADDR=0xf98D5De1014110C65c51b85Ea55f73863215CC10
+    ZKMR_STAKE_REGISTRY_ADDR=0xf724cDC7C40fd6B59590C624E8F0E5E3843b4BE4
+    EIGEN_AVS_DIRECTORY_ADDR=0x055733000064333CaDDbC92763c58BF0192fFeBf
+elif [ $chain_id -eq $MAINNET_CHAINID ]; then
+    echo "Mainnet is not live yet"
+    exit 1
+else
+    echo "Unknown chain ID: $chainId"
+    exit 1
+fi
+
+# --- Script Logic ---
+# The lagrange key should only be used for this AVS.
+# It is an ECDSA secp256k1 keypair; the same as ethereum
+LAGR_KEY=$(openssl ecparam -name secp256k1 -genkey -noout | openssl ec -text -noout)
+LAGR_PUB_KEY=$(echo $LAGR_KEY | grep pub -A 5 | tail -n +2 | tr -d '\n[:space:]:' | sed 's/^04//')
+
+# 32 bytes of X coordinate of ECDSA secp256k1 public key
+pubkeyX=0x${LAGR_PUB_KEY:0:64}
+# 32 bytes of Y coordinate of ECDSA secp256k1 public key
+pubkeyY=0x${LAGR_PUB_KEY:64:64}
+
+printf "Public Key: $LAGR_PUB_KEY\n"
+printf "pubkeyX: $pubkeyX\n"
+printf "pubkeyY: $pubkeyY\n"
+
+# A salt for your signature
+salt=0x$(openssl rand -hex 32)
+
+printf "\nOperator Address: $OPERATOR_ADDR\n"
+printf "ZKMRServiceManager contract: $ZKMR_SERVICE_MANAGER_ADDR\n"
+printf "ZKMRStakeRegistry contract: $ZKMR_STAKE_REGISTRY_ADDR\n"
+printf "Salt for signature: $salt\n"
+printf "Signature expires at: $expiry_timestamp"
+
+# Call read-only method on eigenlayer contract to get hash to sign for registration tx
+hash=$(cast call $EIGEN_AVS_DIRECTORY_ADDR \
+    "calculateOperatorAVSRegistrationDigestHash(address,address,bytes32,uint256)" \
+    "$OPERATOR_ADDR" \
+    "$ZKMR_SERVICE_MANAGER_ADDR" \
+    "${salt}" \
+    "${expiry_timestamp}")
+
+printf "\nRegistration hash:\n${hash}"
+
+# Sign the output
+signature=$(cast wallet sign --private-key $ETH_KEY $hash)
+printf "\nRegistration signature:\n${signature}"
+
+# Register with ZKMR contract using your signature and public key component of your new $LAGR_KEY
+cast send $ZKMR_STAKE_REGISTRY_ADDR \
+    "registerOperator((uint256,uint256),(bytes,bytes32,uint256))" \
+    "(${pubkeyX},${pubkeyY})" \
+    "(${signature},${salt},${expiry_timestamp})" \
+    # === MODIFY ME ! ===
+    --private-key $ETH_KEY # Specify a signer here as you see fit
+
+printf "\nSuccessfully Registered!"
+
+# === MODIFY ME ! ===
+# Modify the script to store the $LAGR_KEY somewhere safe
+# export LAGR_KEY

--- a/register-with-shell.sh
+++ b/register-with-shell.sh
@@ -66,7 +66,7 @@ store_lagrange_key() {
 
 # Determine contract addresses based on the chain ID
 set_contract_addresses() {
-    local chain_id = $(cast chain-id)
+    local chain_id=$(cast chain-id)
 
     if [ -z "$chain_id" ]; then
         echo "Error: Unable to fetch chain ID."
@@ -129,6 +129,7 @@ register_operator() {
         # === MODIFY ME ! ===
         --private-key $ETH_KEY # This line can be adjusted for other signers
         # --aws, --ledger, --trezor, etc.
+
 
     printf "\nSuccessfully Registered!\n"
 }


### PR DESCRIPTION
# Description
An example script using `cast` to register for the Lagrange ZK Coprocessor AVS.
This is an alternative to our Rust CLI. Operators can modify it to suit your operational setup.

This script does 3 things:
1. Generate a new `LAGR_KEY` to be used to authenticate with the Gateway + sign the proofs operators generate. It is needed at runtime while running the worker.
2. Sign a message with your Eigenlayer `ETH_KEY`. This is the very sensitive [withdrawal key](https://docs.eigenlayer.xyz/eigenlayer/operator-guides/key-management/intro#withdrawal-keys)
3. Send a transaction to the `ZKMRStakeRegistry` to register for the ZK Coprocessor AVS

The transaction requires as input:
  1. The public key component of the newly generated `LAGR_KEY`
  2. A signed message from the `ETH_KEY`

It must be signed with the `ETH_KEY` i.e. `cast send --private-key $ETH_KEY`

Operators should update the "MODIFY ME!" sections to load their `ETH_KEY` safely.
They don't need to load the ETH_KEY into the environment at all if they use a remote signer.
They should just modify the `cast send` and `cast sign` commands to sign the hash + tx in a way that meets their security needs.

They also need to update the `OPERATOR_ADDR` variable to match their address.

# Dependencies
1. zsh
2. `cast` - a binary from the foundry toolkit https://github.com/foundry-rs/foundry?tab=readme-ov-file
3. `openssl` - to generate your new ECDSA secp256k1 LAGR_KEY to be used only for the ZK Coprocessor AVS
4. `jq` - only needed for the demo; see the first `=== MODIFY ME! ===` section