### PR TITLE
Update worker-conf.toml

### DIFF
--- a/config/worker-conf.toml
+++ b/config/worker-conf.toml
@@ -15,7 +15,7 @@ worker_id = "CHANGE_THIS_TO_YOUR_OPERATOR_NAME"
 
 params_root_url = "https://pub-d7c7f0d6979a41f2b25137eaecf12d7b.r2.dev"
 
-checksum_url = "/public_params.hash"
+checksum_url = "https://pub-6209c09bbc5e412a9708e493c57edbc9.r2.dev/public_params.hash"
 
 [prometheus]
 port = 9090


### PR DESCRIPTION
fix error: "Error: Failed to fetch checksum file"

`2025-03-23T18:23:07.642004Z  INFO lgn_worker: lgn-worker/src/main.rs:121: Version: 1.0.2
2025-03-23T18:23:07.677283Z  INFO lgn_worker: lgn-worker/src/main.rs:135: Connecting to the gateway at ws://gateway.prod-distributed-query.prod.distributed-query.io:80
2025-03-23T18:23:07.823793Z  INFO lgn_worker: lgn-worker/src/main.rs:177: Connected to the gateway
2025-03-23T18:23:07.823836Z  INFO lgn_worker: lgn-worker/src/main.rs:179: Authenticating
2025-03-23T18:23:07.888293Z  INFO lgn_worker: lgn-worker/src/main.rs:200: connection successful
Error: Failed to fetch checksum file

Caused by:
    0: builder error
    1: relative URL without a base

Stack backtrace:
   0: lgn_worker::checksum::fetch_checksum_file
   1: lgn_worker::main
   2: std::sys::backtrace::__rust_begin_short_backtrace
   3: std::rt::lang_start::{{closure}}
   4: std::rt::lang_start_internal
   5: main
   6: <unknown>
   7: __libc_start_main
   8: _start
`